### PR TITLE
Enable js eslint with support for ECMAScript 6 in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .idea
 .git
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM bitnami/minideb:stretch
+FROM debian:stretch-slim
 LABEL maintainer=""
 
 # Generate locale C.UTF-8 for postgres and general locale data
 ENV LANG C.UTF-8
 ENV VERSION "11.0"
+ENV PY_VERSION "3"
 ENV TESTS "0"
 ENV LINT_CHECK "1"
 ENV TRANSIFEX "0"
@@ -11,19 +12,38 @@ RUN apt-get update && apt-get install -y --no-install-recommends python-pip wget
     && apt-get update && apt-get install -y --no-install-recommends python3-pip wget python3-dev curl \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install setuptools wheel
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - 
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN apt-get update && apt-get install -y git nodejs \
     && rm -rf /var/lib/apt/lists/*
-COPY . /root/maintainer-quality-tools
-RUN pip --no-cache-dir install virtualenv pyyaml  && virtualenv -p python3 venv_py3 && virtualenv venv_py2
+RUN mkdir /root/maintainer-quality-tools
+COPY ./travis /root/maintainer-quality-tools/travis
+COPY ./cfg /root/maintainer-quality-tools/cfg
+COPY ./tests /root/maintainer-quality-tools/tests
+RUN  echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" > etc/apt/sources.list.d/pgdg.list \
+        && export GNUPGHOME="$(mktemp -d)" \
+        && repokey='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8' \
+        && gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "${repokey}" \
+        && gpg --armor --export "${repokey}" | apt-key add - \
+        && gpgconf --kill all \
+        && rm -rf "$GNUPGHOME" \
+        && apt-get update -qq \
+        && apt-get install -yqq postgresql-9.6
+RUN pip --no-cache-dir install virtualenv pyyaml  && virtualenv --system-site-packages -p python3 venv_py3 && virtualenv --system-site-packages venv_py2
 RUN export PATH=${HOME}/maintainer-quality-tools/travis:${PATH} \
-    && . venv_py3/bin/activate && pip --no-cache-dir install pyyaml && travis_install_nightly
+    && . venv_py3/bin/activate && pip3 --no-cache-dir install -I pyyaml coverage && travis_install_nightly
 RUN export PATH=${HOME}/maintainer-quality-tools/travis:${PATH} \
-    && . venv_py2/bin/activate && pip --no-cache-dir install pyyaml && travis_install_nightly
+    && . venv_py2/bin/activate && pip --no-cache-dir install -I  pyyaml coverage && travis_install_nightly
 # install a venv for py3
 
+
+RUN apt-get update && apt-get install -yqq expect python-coverage python3-coverage
+RUN pip3 install coverage
 RUN mkdir /root/src
 VOLUME ["/root/src"]
 RUN cd /usr/bin && ln -s /root/maintainer-quality-tools/travis/travis_run_tests
 COPY ./entrypoint.sh /entrypoint.sh
+
+# enable eslint's es6 support
+COPY sample_files/pre-commit-13.0/.eslintrc.yml /root/.eslintrc.yml
+ENV PYLINT_ODOO_JSLINTRC /root/.eslintrc.yml
 CMD ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -139,6 +139,6 @@ This will run lint and flake checks:
 
     docker build -t travis git@github.com:brain-tec/maintainer-quality-tools.git
     docker run -v full/path/to/repository:/root/src travis
-    
+
 You may use `$(pwd)` to expand the current working directory
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,7 @@ if [ -f ${TRAVIS_FILE} ]; then
 
 else
     echo "Cannot determine the odoo version as ${TRAVIS_FILE} is missing"
+    echo "Please specify env vars for python version PY_VERSION and odoo version VERSION"
 fi
 echo "Testing with Odoo $VERSION using Python $PY_VERSION"
 . "/venv_py$PY_VERSION/bin/activate" && travis_run_tests


### PR DESCRIPTION
This PR enables js checks with ECMA Script V6 for the ckecks in docker.
Do you have any concerns about this?
Can we merge it?

BTW. I think we should enable ECMA Script v6 in travis js checks by default, it is the defacto standard since 2015.
Actually it thows syntax